### PR TITLE
Add presets

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -5,19 +5,21 @@
     <link rel="stylesheet" href="../src/style.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.0/jquery.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.15.0/lodash.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.3.15/angular.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.6.1/angular.min.js"></script>
     <script src="../src/angular-dayparts.js"></script>
     <script>
     angular.module('app', ['angular-dayparts']).controller('main', function($scope){
         $scope.options = {
             reset: true,
-            days: [{name: 'Sunday', position: 1},
+            days: [
+                {name: 'Sunday', position: 1},
                 {name: 'Monday', position: 2},
                 {name: 'Tuesday', position: 3},
                 {name: 'Wednesday', position: 4},
                 {name: 'Thursday', position: 5},
                 {name: 'Friday', position: 6},
-                {name: 'Saturday', position: 7}],
+                {name: 'Saturday', position: 7}
+            ],
             // On Load Value
             onChange: function(selected) {
                 console.log('selected', selected);

--- a/src/style.css
+++ b/src/style.css
@@ -2,6 +2,10 @@
     width: 750px;
 }
 
+.dayparts select {
+  margin: 20px 0;
+}
+
 .dayparts table {
     width: 100%;
 }

--- a/src/template.html
+++ b/src/template.html
@@ -1,4 +1,5 @@
 <div class="dayparts">
+  <select ng-model="selectedPresetItem" ng-options="item.value as item.label disable when item.disabled for item in presetItems" ng-change="selectedPresetItemChanged()"></select>
 
     <table border="0" cellspacing="0" cellpadding="0">
         <tr>


### PR DESCRIPTION
This adds a `<select>` element of presets above the grid of dayparts. When a preset option is selected, the grid reflects days/hours selected. Changes made to the grid are also reflected in the `<select>` element.

![dayparting-presets](https://cloud.githubusercontent.com/assets/1313732/22205984/34c6a774-e147-11e6-8a45-bb5e46f31c22.png)
